### PR TITLE
Only append index to route_name if there is more than one route

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -88,7 +88,10 @@ class FlaskView(object):
                     rule, options = cached_rule
                     rule = cls.build_rule(rule)
                     options = cls.configure_subdomain(options, subdomain)
-                    app.add_url_rule(rule, "%s_%d" % (route_name, idx,), proxy, **options)
+                    if len(cls._rule_cache[name]) == 1:
+                        app.add_url_rule(rule, "%s" % route_name, proxy, **options)
+                    else:
+                        app.add_url_rule(rule, "%s_%d" % (route_name, idx,), proxy, **options)
 
             elif name in special_methods:
                 if name in ["get", "index"]:


### PR DESCRIPTION
I'm actually undecided myself if this is a good idea.
On one hand, if you only define one route, there is no need for the index, and the index did catch me out because I wasn't aware at first that I had to append '_0' to the endpoint when using url_for.
On the other hand, maybe it's best to always attach an index for custom routes. Otherwise, a URL lookup that previously did work may stop working when an additional route is added.
