### PR TITLE
use functools.wraps to set docstrings on proxies

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -10,6 +10,7 @@
 
 __version__ = "0.5.2"
 
+import functools
 import inspect
 from flask import Response, make_response
 import re
@@ -147,8 +148,11 @@ class FlaskView(object):
         :param name: the name of the method to create a proxy for
         """
 
+        i = cls()
+        view = getattr(i, name)
+
+        @functools.wraps(view)
         def proxy(*args, **kwargs):
-            i = cls()
             if hasattr(i, "before_request"):
                 i.before_request(name, *args, **kwargs)
 
@@ -157,7 +161,6 @@ class FlaskView(object):
                 before_view = getattr(i, before_view_name)
                 before_view(*args, **kwargs)
 
-            view = getattr(i, name)
             response = view(*args, **kwargs)
             if not isinstance(response, Response):
                 response = make_response(response)

--- a/test_classy/test_common.py
+++ b/test_classy/test_common.py
@@ -63,6 +63,10 @@ def test_custom_http_method():
     resp = client.post("/basic/route3/")
     eq_("Custom HTTP Method", resp.data)
 
+def test_docstrings():
+    proxy_func = app.view_functions["BasicView:index"]
+    eq_(proxy_func.__doc__, BasicView.index.__doc__)
+
 
 
 

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -3,6 +3,7 @@ from flask_classy import FlaskView, route
 class BasicView(FlaskView):
 
     def index(self):
+        """A docstring for testing that docstrings are set"""
         return "Index"
 
     def get(self, obj_id):


### PR DESCRIPTION
If you use a tool like sphinxcontrib.autohttp.flask to automatically document
your APIs, it's important that the docstrings on the actual view functions be
extractable.  By wrapping the proxy function created in make_proxy_method()
with functools.wraps(), it is set on the proxy function and can be extracted
by walking app.view_functions
