### PR TITLE
Typo in docs - localhost requires port 5000

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ so that everyone knows what a treat they are in for.
         def random(self):
             return choice(quotes)
 
-Load up http://localhost/quotes/word_bacon/ in your browser and behold
+Load up http://localhost:5000/quotes/word_bacon/ in your browser and behold
 your latest achievement.
 
 The route decorator takes exactly the same parameters as Flask's `app.route`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -154,7 +154,7 @@ so that everyone knows what a treat they are in for.
         def random(self):
             return choice(quotes)
 
-Load up http://localhost/quotes/word_bacon/ in your browser and behold
+Load up http://localhost:5000/quotes/word_bacon/ in your browser and behold
 your latest achievement.
 
 The route decorator takes exactly the same parameters as Flask's `app.route`


### PR DESCRIPTION
In the Custom Routes section, port 5000 was accidentally left off the URL.

```
Load up http://localhost/quotes/word_bacon/ in your browser and behold
your latest achievement.
```

Should be 

```
Load up http://localhost:5000/quotes/word_bacon/ in your browser and behold
your latest achievement.
```

to be consistent with the other URLs provided throughout the rest of the Docs.
