### PR TITLE
Support rule arguments in route_base

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -12,6 +12,7 @@ __version__ = "0.5.2"
 
 import functools
 import inspect
+from werkzeug.routing import parse_rule
 from flask import request, Response, make_response
 import re
 
@@ -210,11 +211,14 @@ class FlaskView(object):
 
         route_base = cls.get_route_base()
         rule_parts = [route_base, rule]
+        ignored_rule_args = ['self']
+        if hasattr(cls, 'base_args'):
+            ignored_rule_args += cls.base_args
 
         if method:
             args = inspect.getargspec(method)[0]
             for arg in args:
-                if arg != "self":
+                if arg not in ignored_rule_args:
                     rule_parts.append("<%s>" % arg)
 
         result = "/%s" % "/".join(rule_parts)
@@ -226,6 +230,8 @@ class FlaskView(object):
 
         if hasattr(cls, "route_base"):
             route_base = cls.route_base
+            base_rule = parse_rule(route_base)
+            cls.base_args = [r[2] for r in base_rule]
         else:
             if cls.__name__.endswith("View"):
                 route_base = cls.__name__[:-4].lower()

--- a/flask_classy.py
+++ b/flask_classy.py
@@ -153,11 +153,11 @@ class FlaskView(object):
         view = getattr(i, name)
 
         @functools.wraps(view)
-        def proxy(**forgetable_view_args):
-            # Always pass the global request object's view_args, because they
+        def proxy(**forgettable_view_args):
+            # Always use the global request object's view_args, because they
             # can be modified by intervening function before an endpoint or
             # wrapper gets called. This matches Flask's behavior.
-            del forgetable_view_args
+            del forgettable_view_args
 
             if hasattr(i, "before_request"):
                 i.before_request(name, **request.view_args)

--- a/test_classy/test_endpoints.py
+++ b/test_classy/test_endpoints.py
@@ -38,4 +38,4 @@ def test_variable_route_popped_base():
 def test_variable_route_base():
     with app.test_request_context():
         url = url_for('VarBaseView:with_base_arg', route='bar')
-        eq_('/var-base-route/bar/', url)
+        eq_('/var-base-route/bar/with_base_arg/', url)

--- a/test_classy/test_endpoints.py
+++ b/test_classy/test_endpoints.py
@@ -1,10 +1,12 @@
 from flask import Flask, url_for
-from view_classes import BasicView, IndexView
+from view_classes import BasicView, IndexView, RouteBaseView, VarBaseView
 from nose.tools import *
 
 app = Flask("common")
 BasicView.register(app)
 IndexView.register(app)
+RouteBaseView.register(app)
+VarBaseView.register(app)
 
 client = app.test_client()
 
@@ -23,3 +25,17 @@ def test_custom_endpoint_url():
         url = url_for("basic_endpoint")
         eq_("/basic/endpoint/", url)
 
+def test_custom_route_base():
+    with app.test_request_context():
+        url = url_for('RouteBaseView:index')
+        eq_("/base-routed/", url)
+
+def test_variable_route_popped_base():
+    with app.test_request_context():
+        url = url_for('VarBaseView:index', route='bar')
+        eq_('/var-base-route/bar/', url)
+
+def test_variable_route_base():
+    with app.test_request_context():
+        url = url_for('VarBaseView:with_base_arg', route='bar')
+        eq_('/var-base-route/bar/', url)

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -82,8 +82,8 @@ class VarBaseView(FlaskView):
     def index(self):
         return "Custom routed."
 
-    # def with_base_arg(self, route):
-    #     return "Base route arg: " + route
+    def with_base_arg(self, route):
+        return "Base route arg: " + route
 
 class BeforeRequestView(FlaskView):
 

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -66,6 +66,25 @@ class IndexView(FlaskView):
     def index(self):
         return "Index"
 
+class RouteBaseView(FlaskView):
+    route_base = "/base-routed/"
+
+    def index(self):
+        return "Index"
+
+class VarBaseView(FlaskView):
+    route_base = "/var-base-route/<route>"
+
+    def before_index(self):
+        from flask import request
+        request.view_args.pop('route')
+
+    def index(self):
+        return "Custom routed."
+
+    # def with_base_arg(self, route):
+    #     return "Base route arg: " + route
+
 class BeforeRequestView(FlaskView):
 
     def before_request(self, name):


### PR DESCRIPTION
This pull request maybe should have been two. First, it fixes the behaviour of the arguments passed to the proxied views:
1. As far as I can tell, Flask always calls views with only a `**<dict>`, so we can drop `*args` altogether there unless I'm missing something. Maybe strange use cases of people calling view functions manually? I'll put them back if you think it's an issue. The place where Flask calls view functions seems to be centralized to always go through [this line in flask.app](https://github.com/mitsuhiko/flask/blob/master/flask/app.py#L1466).
   
   The dict that is passed is the one from the global request object. From my own testing with flask's built-in `@before_request` method, it seems you can change the `request.view_args` dict in a `@before_request`, and expect the arguments passed to views to be changed accordingly.
   
   The flask-classy proxy, however, was getting passed `**request.view_args` by flask, and then passing _that_ into the class's `before_request`, `before_<method>`, and finally the actual `view` method, which means it could not be modified.
   
   I'm going on a lot here, and it might seem like a pretty weird use-case, but I wanted to be able to have the modified `request.view_args` passed to my view methods so that I could pull out arguments from `cls.route_base` first. Which leads me to....
2. Support for arguments in `cls.route_base`! I wanted to do class-level pre-processing of arguments in `route_base`, which lead to all kinds of problems before. The main issue was that adding the `route_base` argument to my view's method declaration caused the variable to be added to the rule twice, and making werkzeug throw a -fit- `ValueError`.
   
   So I pulled in `werkzeug.routing.parse_rule` to find any rules in the `route_base` which should not be re-added because of a method declaration, and had them be ignored along with `self` in `build_rules`.

I added some tests which I think cover my changes. Seems to be working fine for me so far. Let me know what you think!
