### PR TITLE
Decorators that accepts kwargs from URL test

### DIFF
--- a/test_classy/test_decorators.py
+++ b/test_classy/test_decorators.py
@@ -13,3 +13,7 @@ def test_func_decorator_index():
 def test_func_decorator_get():
 	resp = client.get('/decorated/1234')
 	eq_(b"Get 1234", resp.data)
+
+def test_func_special_decorator():
+  resp = client.get('/decorated/special/someid')
+  eq_(b"someid1", resp.data)

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -142,7 +142,14 @@ def func_decorator(f):
 def wraps_decorator(f):
     @wraps(f)
     def decorated_view(*args, **kwargs):
-      return f(*args, **kwargs)
+        return f(*args, **kwargs)
+    return decorated_view
+
+def specialized_decorator(f):
+    @wraps(f)
+    def decorated_view(id, *args, **kwargs):
+        transformed_id = id + "1"
+        return f(transformed_id, *args, **kwargs)
     return decorated_view
 
 class DecoratedView(FlaskView):
@@ -153,3 +160,8 @@ class DecoratedView(FlaskView):
     @func_decorator
     def get(self, id):
         return "Get " + id
+
+    @route("/special/<id>")
+    @specialized_decorator
+    def special(self, transformed_id):
+        return transformed_id


### PR DESCRIPTION
Test will fail with saying multiple id keyword. In reality, kwargs will
have `id` and the actually `id` is passed with `self`, an instance of
`DecoratedView`

Test case for #35
