### PR TITLE
Rework trailing slash urls

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -141,9 +141,15 @@ class FlaskView(_FlaskViewBase):
                     else:
                         methods = [name.upper()]
 
+                    # build_rule returns a rule without trailing slash by
+                    # default
                     rule = cls.build_rule("/", value)
                     if not cls.trailing_slash:
                         rule = rule.rstrip("/")
+                    else:
+                        # Add a trailing slash if trailing_slash is True
+                        # (default)
+                        rule = "%s/" % rule
                     app.add_url_rule(rule, route_name, proxy, methods=methods, subdomain=subdomain)
 
                 else:

--- a/test_classy/test_blueprints.py
+++ b/test_classy/test_blueprints.py
@@ -15,15 +15,15 @@ def test_bp_index():
     eq_(b"Index", resp.data)
 
 def test_bp_get():
-    resp = client.get("/basic/1234")
+    resp = client.get("/basic/1234/")
     eq_(b"Get 1234", resp.data)
 
 def test_bp_put():
-    resp = client.put("/basic/1234")
+    resp = client.put("/basic/1234/")
     eq_(b"Put 1234", resp.data)
 
 def test_bp_patch():
-    resp = client.patch("/basic/1234")
+    resp = client.patch("/basic/1234/")
     eq_(b"Patch 1234", resp.data)
 
 def test_bp_post():
@@ -31,7 +31,7 @@ def test_bp_post():
     eq_(b"Post", resp.data)
 
 def test_bp_delete():
-    resp = client.delete("/basic/1234")
+    resp = client.delete("/basic/1234/")
     eq_(b"Delete 1234", resp.data)
 
 def test_bp_custom_method():

--- a/test_classy/test_blueprints.py
+++ b/test_classy/test_blueprints.py
@@ -10,41 +10,51 @@ app.register_blueprint(bp)
 
 client = app.test_client()
 
+
 def test_bp_index():
     resp = client.get("/basic/")
     eq_(b"Index", resp.data)
+
 
 def test_bp_get():
     resp = client.get("/basic/1234/")
     eq_(b"Get 1234", resp.data)
 
+
 def test_bp_put():
     resp = client.put("/basic/1234/")
     eq_(b"Put 1234", resp.data)
+
 
 def test_bp_patch():
     resp = client.patch("/basic/1234/")
     eq_(b"Patch 1234", resp.data)
 
+
 def test_bp_post():
     resp = client.post("/basic/")
     eq_(b"Post", resp.data)
+
 
 def test_bp_delete():
     resp = client.delete("/basic/1234/")
     eq_(b"Delete 1234", resp.data)
 
+
 def test_bp_custom_method():
     resp = client.get("/basic/custom_method/")
     eq_(b"Custom Method", resp.data)
+
 
 def test_bp_custom_method_with_params():
     resp = client.get("/basic/custom_method_with_params/1234/abcd")
     eq_(b"Custom Method 1234 abcd", resp.data)
 
+
 def test_bp_routed_method():
     resp = client.get("/basic/routed/")
     eq_(b"Routed Method", resp.data)
+
 
 def test_bp_multi_routed_method():
     resp = client.get("/basic/route1/")
@@ -53,17 +63,21 @@ def test_bp_multi_routed_method():
     resp = client.get("/basic/route2/")
     eq_(b"Multi Routed Method", resp.data)
 
+
 def test_bp_no_slash():
     resp = client.get("/basic/noslash")
     eq_(b"No Slash Method", resp.data)
+
 
 def test_bp_index_view_index():
     resp = client.get("/")
     eq_(b"Index", resp.data)
 
+
 def test_bp_custom_http_method():
     resp = client.post("/basic/route3/")
     eq_(b"Custom HTTP Method", resp.data)
+
 
 def test_bp_url_prefix():
     foo = Blueprint('foo', __name__)
@@ -72,7 +86,3 @@ def test_bp_url_prefix():
 
     resp = client.get('/foo/')
     eq_(b"Index", resp.data)
-
-
-
-

--- a/test_classy/test_common.py
+++ b/test_classy/test_common.py
@@ -13,15 +13,15 @@ def test_index():
     eq_(b"Index", resp.data)
 
 def test_get():
-    resp = client.get("/basic/1234")
+    resp = client.get("/basic/1234/")
     eq_(b"Get 1234", resp.data)
 
 def test_put():
-    resp = client.put("/basic/1234")
+    resp = client.put("/basic/1234/")
     eq_(b"Put 1234", resp.data)
 
 def test_patch():
-    resp = client.patch("/basic/1234")
+    resp = client.patch("/basic/1234/")
     eq_(b"Patch 1234", resp.data)
 
 def test_post():
@@ -29,7 +29,7 @@ def test_post():
     eq_(b"Post", resp.data)
 
 def test_delete():
-    resp = client.delete("/basic/1234")
+    resp = client.delete("/basic/1234/")
     eq_(b"Delete 1234", resp.data)
 
 def test_custom_method():

--- a/test_classy/test_decorators.py
+++ b/test_classy/test_decorators.py
@@ -13,7 +13,7 @@ def test_func_decorator_index():
 
 
 def test_func_decorator_get():
-    resp = client.get('/decorated/1234')
+    resp = client.get('/decorated/1234/')
     eq_(b"Get 1234", resp.data)
 
 

--- a/test_classy/test_inheritance.py
+++ b/test_classy/test_inheritance.py
@@ -14,7 +14,7 @@ def test_index():
 
 
 def test_override():
-    resp = client.get("/inheritance/1234")
+    resp = client.get("/inheritance/1234/")
     eq_(b"Inheritance Get 1234", resp.data)
 
 def test_inherited():

--- a/test_classy/test_subdomains.py
+++ b/test_classy/test_subdomains.py
@@ -1,5 +1,5 @@
-from flask import Flask, url_for
-from .view_classes import BasicView, IndexView
+from flask import Flask
+from .view_classes import BasicView
 from nose.tools import *
 
 app = Flask("common")
@@ -8,41 +8,53 @@ BasicView.register(app, subdomain="basic")
 
 client = app.test_client()
 
+
 def test_index_subdomain():
     resp = client.get("/basic/", base_url="http://basic.test.test")
     eq_(b"Index", resp.data)
+
 
 def test_get():
     resp = client.get("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Get 1234", resp.data)
 
+
 def test_put():
     resp = client.put("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Put 1234", resp.data)
+
 
 def test_patch():
     resp = client.patch("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Patch 1234", resp.data)
 
+
 def test_post():
     resp = client.post("/basic/", base_url="http://basic.test.test")
     eq_(b"Post", resp.data)
+
 
 def test_delete():
     resp = client.delete("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Delete 1234", resp.data)
 
+
 def test_custom_method():
-    resp = client.get("/basic/custom_method/", base_url="http://basic.test.test")
+    resp = client.get("/basic/custom_method/",
+                      base_url="http://basic.test.test")
     eq_(b"Custom Method", resp.data)
 
+
 def test_custom_method_with_params():
-    resp = client.get("/basic/custom_method_with_params/1234/abcd", base_url="http://basic.test.test")
+    resp = client.get("/basic/custom_method_with_params/1234/abcd",
+                      base_url="http://basic.test.test")
     eq_(b"Custom Method 1234 abcd", resp.data)
+
 
 def test_routed_method():
     resp = client.get("/basic/routed/", base_url="http://basic.test.test")
     eq_(b"Routed Method", resp.data)
+
 
 def test_multi_routed_method():
     resp = client.get("/basic/route1/", base_url="http://basic.test.test")
@@ -50,6 +62,7 @@ def test_multi_routed_method():
 
     resp = client.get("/basic/route2/", base_url="http://basic.test.test")
     eq_(b"Multi Routed Method", resp.data)
+
 
 def test_no_slash():
     resp = client.get("/basic/noslash", base_url="http://basic.test.test")

--- a/test_classy/test_subdomains.py
+++ b/test_classy/test_subdomains.py
@@ -13,15 +13,15 @@ def test_index_subdomain():
     eq_(b"Index", resp.data)
 
 def test_get():
-    resp = client.get("/basic/1234", base_url="http://basic.test.test")
+    resp = client.get("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Get 1234", resp.data)
 
 def test_put():
-    resp = client.put("/basic/1234", base_url="http://basic.test.test")
+    resp = client.put("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Put 1234", resp.data)
 
 def test_patch():
-    resp = client.patch("/basic/1234", base_url="http://basic.test.test")
+    resp = client.patch("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Patch 1234", resp.data)
 
 def test_post():
@@ -29,7 +29,7 @@ def test_post():
     eq_(b"Post", resp.data)
 
 def test_delete():
-    resp = client.delete("/basic/1234", base_url="http://basic.test.test")
+    resp = client.delete("/basic/1234/", base_url="http://basic.test.test")
     eq_(b"Delete 1234", resp.data)
 
 def test_custom_method():

--- a/test_classy/test_trailing_slash.py
+++ b/test_classy/test_trailing_slash.py
@@ -1,5 +1,8 @@
 from flask import Flask
-from .view_classes import BasicView, TrailingSlashView, InheritedTrailingSlashView, OverrideInheritedTrailingSlashView
+from .view_classes import (BasicView,
+                           TrailingSlashView,
+                           InheritedTrailingSlashView,
+                           OverrideInheritedTrailingSlashView)
 from nose.tools import *
 
 app = Flask('trailing_slash')
@@ -10,37 +13,46 @@ OverrideInheritedTrailingSlashView.register(app)
 
 client = app.test_client()
 
+
 def test_index():
     resp = client.get("/basic")
     eq_(b"Index", resp.data)
+
 
 def test_get():
     resp = client.get("/basic/1234")
     eq_(b"Get 1234", resp.data)
 
+
 def test_put():
     resp = client.put("/basic/1234")
     eq_(b"Put 1234", resp.data)
+
 
 def test_patch():
     resp = client.patch("/basic/1234")
     eq_(b"Patch 1234", resp.data)
 
+
 def test_post():
     resp = client.post("/basic")
     eq_(b"Post", resp.data)
+
 
 def test_delete():
     resp = client.delete("/basic/1234")
     eq_(b"Delete 1234", resp.data)
 
+
 def test_custom_method():
     resp = client.get("/basic/custom_method")
     eq_(b"Custom Method", resp.data)
 
+
 def test_custom_method_with_params():
     resp = client.get("/basic/custom_method_with_params/1234/abcd")
     eq_(b"Custom Method 1234 abcd", resp.data)
+
 
 def test_routed_method():
     resp = client.get("/basic/routed/")
@@ -52,38 +64,47 @@ def test_routed_method():
 def test_trailing_index():
     resp = client.get("/trailing")
     eq_(b"Index", resp.data)
-    
+
+
 def test_trailing_get():
     resp = client.get("/trailing/1234")
     eq_(b"Get 1234", resp.data)
+
 
 def test_trailing_put():
     resp = client.put("/trailing/1234")
     eq_(b"Put 1234", resp.data)
 
+
 def test_trailing_patch():
     resp = client.patch("/trailing/1234")
     eq_(b"Patch 1234", resp.data)
+
 
 def test_trailing_post():
     resp = client.post("/trailing")
     eq_(b"Post", resp.data)
 
+
 def test_trailing_delete():
     resp = client.delete("/trailing/1234")
     eq_(b"Delete 1234", resp.data)
+
 
 def test_trailing_custom_method():
     resp = client.get("/trailing/custom_method")
     eq_(b"Custom Method", resp.data)
 
+
 def test_trailing_custom_method_with_params():
     resp = client.get("/trailing/custom_method_with_params/1234/abcd")
     eq_(b"Custom Method 1234 abcd", resp.data)
 
+
 def test_trailing_routed_method():
     resp = client.get("/trailing/routed/")
     eq_(b"Routed Method", resp.data)
+
 
 def test_trailing_routed_method2():
     resp = client.get("/trailing/routed2")

--- a/test_classy/test_trailing_slash.py
+++ b/test_classy/test_trailing_slash.py
@@ -103,3 +103,17 @@ def test_inherited_trailing_slash_override():
     resp = client.get("/override/trailing/")
     eq_(b"Index", resp.data)
 
+
+def test_inherited_trailing_slash_get_a_single_element():
+    resp = client.get("/override/trailing/1/")
+    eq_(b'Get 1', resp.data)
+
+
+def test_inherited_trailing_slash_get_url_without_ending_slash():
+    expect_redirect = 301
+    expect_success = 200
+    resp = client.get("/override/trailing/1")
+    eq_(expect_redirect, resp.status_code)
+
+    resp = client.get("/override/trailing/1", follow_redirects=True)
+    eq_(expect_success, resp.status_code)

--- a/test_classy/test_view_wrappers.py
+++ b/test_classy/test_view_wrappers.py
@@ -34,7 +34,7 @@ def test_decorated_view():
     resp = client.get("/decorated/")
     eq_(b"Index", resp.data)
 
-    resp = client.get("/decorated/1234")
+    resp = client.get("/decorated/1234/")
     eq_(b"Get 1234", resp.data)
 
 

--- a/test_classy/test_view_wrappers.py
+++ b/test_classy/test_view_wrappers.py
@@ -1,6 +1,11 @@
 from flask import Flask
-from .view_classes import (BeforeRequestView, BeforeViewView, AfterRequestView, AfterViewView, DecoratedView,
-                           BeforeRequestReturnsView, BeforeViewReturnsView)
+from .view_classes import (BeforeRequestView,
+                           BeforeViewView,
+                           AfterRequestView,
+                           AfterViewView,
+                           DecoratedView,
+                           BeforeRequestReturnsView,
+                           BeforeViewReturnsView)
 from nose.tools import *
 
 app = Flask("wrappers")
@@ -14,21 +19,26 @@ DecoratedView.register(app)
 
 client = app.test_client()
 
+
 def test_before_request():
     resp = client.get("/beforerequest/")
     eq_(b"Before Request", resp.data)
+
 
 def test_before_view():
     resp = client.get("/beforeview/")
     eq_(b"Before View", resp.data)
 
+
 def test_after_view():
     resp = client.get("/afterview/")
     eq_(b"After View", resp.data)
 
+
 def test_after_request():
     resp = client.get("/afterrequest/")
     eq_(b"After Request", resp.data)
+
 
 def test_decorated_view():
     resp = client.get("/decorated/")
@@ -41,6 +51,7 @@ def test_decorated_view():
 def test_before_request_returns():
     resp = client.get("/beforerequestreturns/")
     eq_(b"BEFORE", resp.data)
+
 
 def test_before_view_returns():
     resp = client.get("/beforeviewreturns/")


### PR DESCRIPTION
When using:

`trailing_slash = True` -- the default

I had mixed URLs for:
- POST (trailing slash)
- GET (trailing slash)
- GET id (no trailing slash)
- PUT id (no trailing slash)
- DELETE id (no trailing slash)

I don't know if this behaviour was intended.
Anyway I have prepared this PR to adapt the behaviour, I will close it if it does not make sense

Other **note**. With this patch if someone uses `trailing_slash = True` it will get consistent trailing slashes and `301` redirects to trailing slash urls

Other than the change itself, I adapted the pre-existing tests that were failing after introducing 804f20b

Let me know thanks ;)
