### PR TITLE
Prevents rule processing loop from smashing non-subdomain rules

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -123,8 +123,10 @@ class FlaskView(_FlaskViewBase):
                         rule = cls.build_rule(rule)
                         sub, ep, options = cls.parse_options(options)
 
-                        if not subdomain and sub:
+                        if sub:
                             subdomain = sub
+                        else:
+                            subdomain = None
 
                         if ep:
                             endpoint = ep


### PR DESCRIPTION
Ran into a case where I've got a viewclass that needs to define both subdomain and non subdomain'd routes.  Took me a while to track down where it was happening, but if a subdomain route happened to appear early in the file, it would smash any non-subdomain'd route later.
