### PR TITLE
Fix route inheritance issues

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -17,7 +17,6 @@ from werkzeug.routing import parse_rule
 from flask import request, Response, make_response
 import re
 
-_temp_rule_cache = None
 _py2 = sys.version_info[0] == 2
 
 
@@ -28,38 +27,23 @@ def route(rule, **options):
     """
 
     def decorator(f):
-        global _temp_rule_cache
-        if _temp_rule_cache is None:
-            _temp_rule_cache = {f.__name__: [(rule, options)]}
-        elif not f.__name__ in _temp_rule_cache:
-            _temp_rule_cache[f.__name__] = [(rule, options)]
+        # Put the rule cache on the method itself instead of globally
+        if not hasattr(f, '_rule_cache') or f._rule_cache is None:
+            f._rule_cache = {f.__name__: [(rule, options)]}
+        elif not f.__name__ in f._rule_cache:
+            f._rule_cache[f.__name__] = [(rule, options)]
         else:
-            _temp_rule_cache[f.__name__].append((rule, options))
+            f._rule_cache[f.__name__].append((rule, options))
 
         return f
 
     return decorator
 
 
-class _FlaskViewMeta(type):
-
-    def __init__(cls, name, bases, dct):
-        global _temp_rule_cache
-        if _temp_rule_cache:
-            cls._rule_cache = _temp_rule_cache
-            _temp_rule_cache = None
-
-
-# This is how we support metaclasses in both Python 2 and Python 3
-_FlaskViewBase = _FlaskViewMeta('_FlaskViewBase', (object, ), {})
-
-
-class FlaskView(_FlaskViewBase):
+class FlaskView(object):
     """Base view for any class based views implemented with Flask-Classy. Will
     automatically configure routes when registered with a Flask app instance.
     """
-
-    __metaclass__ = _FlaskViewMeta
 
     decorators = []
     route_base = None
@@ -117,8 +101,8 @@ class FlaskView(_FlaskViewBase):
             proxy = cls.make_proxy_method(name)
             route_name = cls.build_route_name(name)
             try:
-                if hasattr(cls, "_rule_cache") and name in cls._rule_cache:
-                    for idx, cached_rule in enumerate(cls._rule_cache[name]):
+                if hasattr(value, "_rule_cache") and name in value._rule_cache:
+                    for idx, cached_rule in enumerate(value._rule_cache[name]):
                         rule, options = cached_rule
                         rule = cls.build_rule(rule)
                         sub, ep, options = cls.parse_options(options)
@@ -128,7 +112,7 @@ class FlaskView(_FlaskViewBase):
 
                         if ep:
                             endpoint = ep
-                        elif len(cls._rule_cache[name]) == 1:
+                        elif len(value._rule_cache[name]) == 1:
                             endpoint = route_name
                         else:
                             endpoint = "%s_%d" % (route_name, idx,)

--- a/test_classy/test_inheritance.py
+++ b/test_classy/test_inheritance.py
@@ -29,3 +29,7 @@ def test_with_route():
 def test_override_with_route():
     resp = client.delete("/inheritance/1234/delete")
     eq_(b"Inheritance Delete 1234", resp.data)
+
+def test_inherited_base_route():
+    resp = client.get("/inheritance/routed/")
+    eq_(b"Routed Method", resp.data)


### PR DESCRIPTION
The route decorator was broken for base views in inheritance. See issue #39 and #43.

`_temp_rule_cache` is removed and the `_rule_cache` now lives in the method itself.
This fixes inheritance issues.

``` python
class GenericView(FlaskView):
    @route('/page/<int(1):page>')
    @route('/', defaults={'page': 1})
    def index(self, page):
        return str(page)

class PostsView(GenericView):
    route_base = '/'

PostsView.register(app)
GenericView.register(app)
```

`app.url_map` will now contain

```
Map([<Rule '/generic/page/<page>' (GET, HEAD, OPTIONS) -> GenericView:index_1>,
 <Rule '/page/<page>' (GET, HEAD, OPTIONS) -> PostsView:index_1>,
 <Rule '/generic/' (GET, HEAD, OPTIONS) -> GenericView:index_0>,
 <Rule '/' (GET, HEAD, OPTIONS) -> PostsView:index_0>])
```
