### PR TITLE
Decompose large blocks in FlaskView

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -65,6 +65,14 @@ class FlaskView(_FlaskViewBase):
     route_base = None
     route_prefix = None
     trailing_slash = True
+    special_methods = {
+        "get": ["GET"],
+        "put": ["PUT"],
+        "patch": ["PATCH"],
+        "post": ["POST"],
+        "delete": ["DELETE"],
+        "index": ["GET"],
+    }
 
     @classmethod
     def register(cls, app, route_base=None, subdomain=None, route_prefix=None,
@@ -111,7 +119,6 @@ class FlaskView(_FlaskViewBase):
 
 
         members = get_interesting_members(FlaskView, cls)
-        special_methods = ["get", "put", "patch", "post", "delete", "index"]
 
         for name, value in members:
             proxy = cls.make_proxy_method(name)
@@ -135,11 +142,8 @@ class FlaskView(_FlaskViewBase):
 
                         app.add_url_rule(rule, endpoint, proxy, subdomain=subdomain, **options)
 
-                elif name in special_methods:
-                    if name in ["get", "index"]:
-                        methods = ["GET"]
-                    else:
-                        methods = [name.upper()]
+                elif name in cls.special_methods:
+                    methods = cls.special_methods[name]
 
                     rule = cls.build_rule("/", value)
                     if not cls.trailing_slash:

--- a/flask_classy.py
+++ b/flask_classy.py
@@ -279,12 +279,16 @@ class FlaskView(_FlaskViewBase):
             base_rule = parse_rule(route_base)
             cls.base_args = [r[2] for r in base_rule]
         else:
-            if cls.__name__.endswith("View"):
-                route_base = cls.__name__[:-4].lower()
-            else:
-                route_base = cls.__name__.lower()
+            route_base = cls.default_route_base()
 
         return route_base.strip("/")
+
+    @classmethod
+    def default_route_base(cls):
+        if cls.__name__.endswith("View"):
+            return cls.__name__[:-4].lower()
+        else:
+            return cls.__name__.lower()
 
 
     @classmethod


### PR DESCRIPTION
I found this project while writing a completely parallel class, and given that the work's already done, I ran with it.  One issue I had was wanting to subclass FlaskView to override some pieces of behavior, but because of method body length, much copy/paste was required to make the minor behavior changes I was after.  This pull request involves no behavior changes, but just pulls a few things out into their own space on FlaskView, so clients can override them without affecting anything else.
