### PR TITLE
Added make_response to FlaskView as a class method

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -161,6 +161,11 @@ class FlaskView(object):
         endpoint = options.pop('endpoint', None)
         return subdomain, endpoint, options,
 
+    @classmethod
+    def make_response(cls, response):
+        """Allows one to override Flask's make_response function.  This provides
+        an inheritable final decorator on the view being returned."""
+        return make_response(response)
 
     @classmethod
     def make_proxy_method(cls, name):
@@ -199,7 +204,7 @@ class FlaskView(object):
 
             response = view(**request.view_args)
             if not isinstance(response, Response):
-                response = make_response(response)
+                response = cls.make_response(response)
 
             after_view_name = "after_" + name
             if hasattr(i, after_view_name):

--- a/test_classy/test_view_wrappers.py
+++ b/test_classy/test_view_wrappers.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .view_classes import (BeforeRequestView, BeforeViewView, AfterRequestView, AfterViewView, DecoratedView,
-                           BeforeRequestReturnsView, BeforeViewReturnsView)
+                           BeforeRequestReturnsView, BeforeViewReturnsView, MakeResponseView)
 from nose.tools import *
 
 app = Flask("wrappers")
@@ -11,6 +11,7 @@ BeforeViewReturnsView.register(app)
 AfterViewView.register(app)
 AfterRequestView.register(app)
 DecoratedView.register(app)
+MakeResponseView.register(app)
 
 client = app.test_client()
 
@@ -45,3 +46,7 @@ def test_before_request_returns():
 def test_before_view_returns():
     resp = client.get("/beforeviewreturns/")
     eq_(b"BEFORE", resp.data)
+
+def test_make_response_view():
+    resp = client.get("/makeresponse/")
+    eq_(b"Make Response", resp.data)

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -149,6 +149,15 @@ class AfterRequestView(FlaskView):
     def index(self):
         return "Index"
 
+class MakeResponseView(FlaskView):
+
+    @classmethod
+    def make_response(cls, response):
+        return "Make Response"
+
+    def index(self):
+        return "Index"
+
 class VariedMethodsView(FlaskView):
 
     def index(self):


### PR DESCRIPTION
I've added the ability to override Flask's `make_response` function by adding a new `make_response` class method to FlaskView.

The motivation is to provide an final and inheritable "decorator-like" function that wraps the view's response.

Decorators are inheritable; however, if a subclass wishes to modify the decorator list, they need to be aware of the parents decorators to do so.

I'm not sure if this function should be an instance function or a class method.  I've created it as a class method; however, I'd be willing to change it to an instance method to provide easier and cleaner subclassing.

My personal motivation for this pull request is to replace [Flask-RESTful](https://github.com/twilio/flask-restful)'s `MethodView` with `FlaskView`.  

I like the design where the API views return the data directly and the `make_response` provides the final conversion to the output representation requested.
