### PR TITLE
allow for kwargs to be passed to decorators list

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -176,7 +176,7 @@ class FlaskView(object):
 
         if cls.decorators:
             for decorator in cls.decorators:
-                view = decorator(view)
+                view = decorator[0](view, **decorator[1]) or decorator(view)
 
         @functools.wraps(view)
         def proxy(**forgettable_view_args):


### PR DESCRIPTION
Assumes loop element is a tuple of the decorator and the dict() of kwargs, but will fall-over to a plain old decorator.
