### PR TITLE
Calling `flask.abort()` should not ignore `FlaskView.after_request`.

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -203,7 +203,7 @@ class FlaskView(object):
             except HTTPException as response:
                 raise response
             finally:
-                if not isinstance(response, Response):
+                if response and not isinstance(response, Response):
                     response = make_response(response)
 
                 after_view_name = "after_" + name

--- a/test_classy/test_view_wrappers.py
+++ b/test_classy/test_view_wrappers.py
@@ -30,6 +30,11 @@ def test_after_request():
     resp = client.get("/afterrequest/")
     eq_(b"After Request", resp.data)
 
+def test_after_request_with_abort():
+    resp = client.post("/afterrequest/")
+    ok_(b"Stopped by post" in resp.data)
+    ok_(AfterRequestView.after_called == True)
+
 def test_decorated_view():
     resp = client.get("/decorated/")
     eq_(b"Index", resp.data)

--- a/test_classy/test_view_wrappers.py
+++ b/test_classy/test_view_wrappers.py
@@ -35,6 +35,11 @@ def test_after_request_with_abort():
     ok_(b"Stopped by post" in resp.data)
     ok_(AfterRequestView.after_called == True)
 
+def test_after_request_with_error():
+    resp = client.put("/afterrequest/")
+    eq_(resp.status_code, 500)
+    ok_(AfterRequestView.after_called == True)
+
 def test_decorated_view():
     resp = client.get("/decorated/")
     eq_(b"Index", resp.data)

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -1,3 +1,4 @@
+from flask import abort
 from flask_classy import FlaskView, route
 from functools import wraps
 
@@ -143,11 +144,18 @@ class AfterViewView(FlaskView):
 
 class AfterRequestView(FlaskView):
 
+    def before_request(self, name):
+        self.__class__.after_called = False
+
     def after_request(self, name, response):
+        self.__class__.after_called = True
         return "After Request"
 
     def index(self):
         return "Index"
+
+    def post(self):
+        abort(422, "Stopped by post")
 
 class VariedMethodsView(FlaskView):
 

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -157,6 +157,9 @@ class AfterRequestView(FlaskView):
     def post(self):
         abort(422, "Stopped by post")
 
+    def put(self):
+        error('UnknownError')
+
 class VariedMethodsView(FlaskView):
 
     def index(self):


### PR DESCRIPTION
This small change makes it possible to use `abort()` inside the views without cancelling the `after_request` method calls.

Thanks in advance for reviewing this and for the great extension!
