### PR TITLE
Decorator chain using explicit arguments

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -15,6 +15,7 @@ import functools
 import inspect
 from werkzeug.routing import parse_rule
 from flask import request, Response, make_response
+from undecorated import undecorated
 import re
 
 _py2 = sys.version_info[0] == 2
@@ -294,26 +295,7 @@ def get_interesting_members(base_class, cls):
 def get_true_argspec(method):
     """Drills through layers of decorators attempting to locate the actual argspec for the method."""
 
-    argspec = inspect.getargspec(method)
-    args = argspec[0]
-    if args and args[0] == 'self':
-        return argspec
-    if hasattr(method, '__func__'):
-        method = method.__func__
-    if not hasattr(method, '__closure__') or method.__closure__ is None:
-        raise DecoratorCompatibilityError
-
-    closure = method.__closure__
-    for cell in closure:
-        inner_method = cell.cell_contents
-        if inner_method is method:
-            continue
-        if not inspect.isfunction(inner_method) \
-            and not inspect.ismethod(inner_method):
-            continue
-        true_argspec = get_true_argspec(inner_method)
-        if true_argspec:
-            return true_argspec
+    return inspect.getargspec(undecorated(method))
 
 
 class DecoratorCompatibilityError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
+        'undecorated',
         'Flask>=0.9'
     ],
     classifiers=[

--- a/test_classy/test_decorators.py
+++ b/test_classy/test_decorators.py
@@ -56,4 +56,6 @@ def test_params_decorator_delete():
     eq_(b"Params Decorator Delete 1234", resp.data)
 
 
-
+def test_explicit_params_decorator():
+    resp = client.get('/decorated/explicit/foo/bar')
+    eq_(b"Explicit param foobar", resp.data)

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -186,6 +186,13 @@ def params_decorator(p_1, p_2):
     return decorator
 
 
+def explicit_params_decorator(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper
+
+
 def recursive_decorator(f):
     @wraps(f)
     def decorated_view(*args, **kwargs):
@@ -253,6 +260,9 @@ class DecoratedView(FlaskView):
     def anotherval(self, val):
         return "Anotherval " + val
 
+    @explicit_params_decorator
+    def explicit(self, arg1, arg2):
+        return "Explicit param " + arg1 + arg2
 
 
 class InheritanceView(BasicView):

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -188,8 +188,8 @@ def params_decorator(p_1, p_2):
 
 def explicit_params_decorator(f):
     @wraps(f)
-    def wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
+    def wrapper(self, arg1, *args, **kwargs):
+        return f(self, arg1, *args, **kwargs)
     return wrapper
 
 


### PR DESCRIPTION
If one of the decorators in the chain of a method's decorators specifies
(at least one) of its parameter names explicitly, classy fails to build
a correct route for it. The `get_true_argspec` function will stop at
that decorator because it has found that its first argument is `self`.

This pull request contains a failing test which points out the issue. I
haven't figured out a fix yet.
