### PR TITLE
use "inspect.getfullargspec()" instead of "inspect.getargspec"

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -294,7 +294,7 @@ def get_interesting_members(base_class, cls):
 def get_true_argspec(method):
     """Drills through layers of decorators attempting to locate the actual argspec for the method."""
 
-    argspec = inspect.getargspec(method)
+    argspec = inspect.getfullargspec(method)
     args = argspec[0]
     if args and args[0] == 'self':
         return argspec


### PR DESCRIPTION
according to the the documentation of [inspect](https://docs.python.org/3.6/library/inspect.html#inspect.getargspec) you should use getfullargspec, which is a drop-in replacement for getargspec